### PR TITLE
feat: 뱃지 이미지 조회 엔드포인트 구현

### DIFF
--- a/src/main/java/org/bf/pointservice/application/dto/BadgeImageResponse.java
+++ b/src/main/java/org/bf/pointservice/application/dto/BadgeImageResponse.java
@@ -1,0 +1,6 @@
+package org.bf.pointservice.application.dto;
+
+public record BadgeImageResponse(
+        String imgUrl
+) {
+}

--- a/src/main/java/org/bf/pointservice/application/query/BadgeQueryService.java
+++ b/src/main/java/org/bf/pointservice/application/query/BadgeQueryService.java
@@ -12,4 +12,7 @@ public interface BadgeQueryService {
 
     // 단일 뱃지 조회
     BadgeResponse getBadge(UUID badgeId);
+
+    // 뱃지 이미지 조회
+    String getBadgeImage(UUID userId);
 }

--- a/src/main/java/org/bf/pointservice/presentation/BadgeController.java
+++ b/src/main/java/org/bf/pointservice/presentation/BadgeController.java
@@ -6,6 +6,7 @@ import org.bf.global.infrastructure.CustomResponse;
 import org.bf.global.infrastructure.success.GeneralSuccessCode;
 import org.bf.pointservice.application.command.BadgeCommandService;
 import org.bf.pointservice.application.dto.BadgeCreateRequest;
+import org.bf.pointservice.application.dto.BadgeImageResponse;
 import org.bf.pointservice.application.dto.BadgeResponse;
 import org.bf.pointservice.application.dto.BadgeUpdateRequest;
 import org.bf.pointservice.application.query.BadgeQueryService;
@@ -67,5 +68,14 @@ public class BadgeController {
     public CustomResponse<BadgeResponse> getBadge(@PathVariable("badgeId") UUID badgeId) {
         BadgeResponse response = badgeQueryService.getBadge(badgeId);
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, response);
+    }
+
+    /**
+     * 프론트에서 뱃지 이미지를 조회
+     * */
+    @GetMapping("/image/{userId}")
+    public CustomResponse<BadgeImageResponse> getBadgeImage(@PathVariable UUID userId) {
+        String url = badgeQueryService.getBadgeImage(userId);
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, new BadgeImageResponse(url));
     }
 }


### PR DESCRIPTION
- 제목 : feat(#43): 뱃지 이미지 조회 엔드포인트 구현

## 🔘Part

- application.dto.BadgeImageResponse
- application.query.BadgeQueryService
- presentation.BadgeController

## 🔎 작업 내용

- 프론트용 뱃지 이미지 조회 엔드포인트 구현


## 🔧 점검 내용

- 관리자가 유의해서 확인해야할 내용이
- 있다면 적어주세요

## ➕ 이슈 링크

- [#43](https://github.com/Barrier-Free-Friends/point-service/issues/43)